### PR TITLE
feat: 이벤트 상세페이지 구현

### DIFF
--- a/client/src/components/molecule/eventDetail/OfflineContent.jsx
+++ b/client/src/components/molecule/eventDetail/OfflineContent.jsx
@@ -8,12 +8,10 @@ export default function OfflineContent({ event }) {
   return (
     <div className="OfflineContent">
       <div className="iframe-wrap">
-        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1093.5332439980473!2d127.05657308892782!3d37.54514038587329!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x357ca495c5b77f07%3A0x393d4d25c63b9b6!2z7KCc6rCV67mM65Sp!5e0!3m2!1sko!2skr!4v1598536924894!5m2!1sko!2skr"></iframe>
-        {/* <iframe
-          src={`https://www.google.com/maps/embed/v1/place?key=AIzaSyB_BJhQ4nBvi7cPxi8DRGJepYp4MbdtRcQ&q=${event.location.details}`}
+        <iframe
+          src={`https://www.google.com/maps/embed/v1/place?key=AIzaSyB_BJhQ4nBvi7cPxi8DRGJepYp4MbdtRcQ&q=${loactionDetails}`}
           frameBorder="0"
-        ></iframe> */}
-        {/* 위 부분인데 event에서 받아온 location.details를 &q=라는 파라미터에 넣어주시면 됩니당*/}
+        ></iframe>
       </div>
       <table>
         <tbody>
@@ -24,11 +22,10 @@ export default function OfflineContent({ event }) {
           <tr>
             <th>상세 주소</th>
             <td>{loactionDetails}</td>
-            {/* event.location.details는 지도 쿼리로 입력한 인풋 value입니다 아마 상세주소는 밑에 인포랑 좀 겹치는 감이 조금 있네요 이거는 따로 얘기해봐야될 거 같네요 */}
           </tr>
           <tr>
             <th>장소 설명</th>
-            <td>{loactionInfo}.</td>
+            <td>{loactionInfo}</td>
           </tr>
         </tbody>
       </table>

--- a/client/src/components/organism/eventDetail/EventContents.jsx
+++ b/client/src/components/organism/eventDetail/EventContents.jsx
@@ -11,10 +11,10 @@ export default function EventContents({ event }) {
   return (
     <div className="eventContents-wrap">
       <div
-        className="content"
+        className="content tui-editor-contents"
         dangerouslySetInnerHTML={innerHtml(content)}
       ></div>
-      {isOnline && <OfflineContent event={event} />}
+      {!isOnline && <OfflineContent event={event} />}
     </div>
   );
 }

--- a/client/src/components/organism/eventDetail/EventContents.scss
+++ b/client/src/components/organism/eventDetail/EventContents.scss
@@ -9,7 +9,6 @@
   font-size: 1.5rem;
   .content {
     padding: 30px;
-    background-color: #f2f3f6;
   }
   .iframe-wrap {
     margin-top: 50px;

--- a/client/src/components/organism/eventDetail/EventInfo.jsx
+++ b/client/src/components/organism/eventDetail/EventInfo.jsx
@@ -93,10 +93,6 @@ export default function EventInfo({ event }) {
                 <td>{hostEmail}</td>
               </tr>
               <tr>
-                <th>주최자 연락처</th>
-                <td>010</td>
-              </tr>
-              <tr>
                 <th>현재 참가자</th>
                 <td>
                   <span>{curCount}</span>

--- a/client/src/components/organism/eventDetail/EventInfo.jsx
+++ b/client/src/components/organism/eventDetail/EventInfo.jsx
@@ -40,7 +40,7 @@ export default function EventInfo({ event }) {
         <div className="left">
           <div
             className="thumbnail"
-            style={{ backgroundImage: `url(${thumbnail})` }}
+            style={thumbnail && { backgroundImage: `url(${thumbnail})` }}
           ></div>
         </div>
         <div className="right">
@@ -83,7 +83,11 @@ export default function EventInfo({ event }) {
                 <td>
                   <span
                     className="host-thumbnail"
-                    style={{ backgroundImage: `url(${hostProfileImg})` }}
+                    style={
+                      hostProfileImg && {
+                        backgroundImage: `url(${hostProfileImg})`,
+                      }
+                    }
                   ></span>
                   <span>{hostName}</span>
                 </td>

--- a/client/src/components/organism/eventDetail/Eventinfo.scss
+++ b/client/src/components/organism/eventDetail/Eventinfo.scss
@@ -106,7 +106,7 @@
 }
 
 @include mobile {
-  .offlineInfo-wrap {
+  .eventInfo-wrap {
     .flex-wrap {
       h2 {
         margin-top: 50px;
@@ -128,7 +128,7 @@
 }
 
 @include tablet {
-  .offlineInfo-wrap {
+  .eventInfo-wrap {
     .flex-wrap {
       h2 {
         margin-top: 50px;

--- a/client/src/components/template/EventDetailTemplate.jsx
+++ b/client/src/components/template/EventDetailTemplate.jsx
@@ -5,6 +5,10 @@ import EventInfo from '../organism/eventDetail/EventInfo';
 import EventContents from '../organism/eventDetail/EventContents';
 
 export default function EventDetailTemplate({ event }) {
+  useEffect(() => {
+    document.title = event && event.title;
+    window.scrollTo(0, 0);
+  }, [event]);
   return (
     <main className="main">
       <div className="eventDetail">

--- a/client/src/components/template/EventDetailTemplate.jsx
+++ b/client/src/components/template/EventDetailTemplate.jsx
@@ -1,12 +1,11 @@
 import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
 import './EventDetailTemplate.scss';
 import EventInfo from '../organism/eventDetail/EventInfo';
 import EventContents from '../organism/eventDetail/EventContents';
 
 export default function EventDetailTemplate({ event }) {
   useEffect(() => {
-    document.title = event && event.title;
+    document.title = event ? event.title : 'Surfesta';
     window.scrollTo(0, 0);
   }, [event]);
   return (

--- a/client/src/components/template/EventsTemplate.jsx
+++ b/client/src/components/template/EventsTemplate.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Card from '../organism/main/Card';
 import './EventsTemplate.scss';
 import Search from '../organism/Search';
@@ -7,6 +7,10 @@ import errorImg from '../../img/error.png';
 
 // Presentational Component
 export default function EventsTemplate({ events, loading, error }) {
+  useEffect(() => {
+    document.title = '🏄‍♀️ Surfesta';
+  }, []);
+
   return (
     <main className="main">
       <h2 className="a11y-hidden">이벤트 검색</h2>

--- a/client/src/style/theme.scss
+++ b/client/src/style/theme.scss
@@ -4,6 +4,7 @@ body.dark {
   // backgrounds
   .main {
     background-color: #1b1d21;
+    transition: all 0.2s ease-in-out;
   }
   .center input {
     background-color: #1b1d21;
@@ -96,6 +97,22 @@ body.dark {
     }
   }
   .eventContents-wrap {
+    .content {
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      p,
+      ul,
+      ol,
+      li,
+      table,
+      a {
+        color: $dark-font-primary-color;
+      }
+    }
     table {
       color: $dark-font-primary-color;
     }

--- a/client/src/style/theme.scss
+++ b/client/src/style/theme.scss
@@ -98,6 +98,7 @@ body.dark {
   }
   .eventContents-wrap {
     .content {
+      color: $dark-font-primary-color;
       h1,
       h2,
       h3,


### PR DESCRIPTION
- #79 
- 주최자 연락처 지움
- 라우팅 후 스크롤 탑으로 감
- 다크모드일때 사용자입력 컨텐츠 색상 #f2f3f6으로 통일
- 구글맵 테스트 완료
- 온,오프라인에 따라 컨텐츠(지도)  바뀜
